### PR TITLE
イベント関連の表示スタイルを整える

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: event, local: true, data: { disable_with: "保存中..." }) do |f| %>
   <div class="mb-6">
     <%= f.label(:title, "タイトル", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.text_field(:title, placeholder: "イベントのタイトル (最大50文字)", class: "shadow-sm appearance-none border #{'border-red-500' if event.errors[:title].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <%= f.text_field(:title, placeholder: "イベントのタイトル (最大50文字)", class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:title].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
     <% if event.errors[:title].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:title].join(", ") %></p>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="mb-6">
     <%= f.label(:description, "説明", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.text_area(:description, placeholder: "イベントの概要 (最大200文字)", rows: 4, class: "shadow-sm appearance-none border #{'border-red-500' if event.errors[:description].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <%= f.text_area(:description, placeholder: "イベントの概要 (最大200文字)", rows: 4, class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:description].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
     <% if event.errors[:description].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:description].join(", ") %></p>
     <% end %>
@@ -17,7 +17,7 @@
 
   <div class="mb-6">
     <%= f.label(:start_at, "開始日時", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.datetime_local_field(:start_at, class: "shadow-sm appearance-none border #{'border-red-500' if event.errors[:start_at].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <%= f.datetime_local_field(:start_at, class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:start_at].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
     <% if event.errors[:start_at].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:start_at].join(", ") %></p>
     <% end %>
@@ -25,7 +25,7 @@
 
   <div class="mb-6">
     <%= f.label(:venue, "会場", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.text_field(:venue, placeholder: "談話室 or 公民館 or ...", class: "shadow-sm appearance-none border #{'border-red-500' if event.errors[:venue].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <%= f.text_field(:venue, placeholder: "談話室 or 公民館 or ...", class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:venue].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
     <% if event.errors[:venue].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:venue].join(", ") %></p>
     <% end %>
@@ -33,7 +33,7 @@
 
   <div class="mb-6">
     <%= f.label(:source_link, "詳細リンク", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.text_field(:source_link, placeholder: "https://discord.com/...", class: "shadow-sm appearance-none border #{'border-red-500' if event.errors[:source_link].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <%= f.text_field(:source_link, placeholder: "https://discord.com/...", class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:source_link].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
     <% if event.errors[:source_link].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:source_link].join(", ") %></p>
     <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title) { @event.title } %>
 
 <article class="bg-white rounded-lg shadow-lg p-6">
-  <h1 class="font-bold text-4xl mb-4"><%= @event.title %></h1>
+  <h1 class="font-bold text-2xl mb-4"><%= @event.title %></h1>
   <div class="mb-8">
     <p class="text-gray-700 mb-4"><%= @event.description %></p>
     <div>


### PR DESCRIPTION
- https://github.com/devin-sandbox/manabiya/pull/148 の影響でイベントのフォームの入力要素の背景の白が消えて背景とのコントラストが低くなっていたので、白を敷き直す
- イベント個別ページのイベント名のフォントサイズが大きすぎたので、アプリケーション全体のトーンに合わせてほどよい大きさにする
