### PR TITLE
フリースクールのボランティアの参加状況を通知していく

### DIFF
--- a/app/jobs/school_stats_notifier_job.rb
+++ b/app/jobs/school_stats_notifier_job.rb
@@ -1,0 +1,9 @@
+class SchoolStatsNotifierJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return if Oyasumi.oyasumi?(Date.today)
+
+    Notification.new.notify_school_stats
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,6 +55,20 @@ class Notification
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end
 
+  def notify_school_stats
+    thread_id = Rails.application.credentials.dig("discord", "school_thread_id")
+
+    schedules = Schedule.joins(:assignment).where("schedules.date >= ?", 30.days.ago.to_date)
+    content = "実状把握のため、参加される方はManabiyaからスケジュール登録してもらえるとうれしいです :dizzy:"
+    title = "過去30日間のコンボラ参加は%d件でした" % schedules.count
+    description = schedules.
+                  group(:member).count.sort_by { _2 }.reverse.
+                  map { |m, c| "<@!%s> %d件" % [m.discord_uid, c] }.join(" / ")
+    embeds = [{ title:, description:, }]
+
+    pp @bot.send_message(channel_or_thread_id: thread_id, content:, embeds:)
+  end
+
   def notify_member_region_created(member_region)
     thread_id = Rails.application.credentials.dig("discord", "profile_thread_id")
     region_with_category = "「%s」(%s)" % [member_region.region.name, member_region.category]

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,11 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+default: &default
+  school_stats_notifier:
+    class: SchoolStatsNotifierJob
+    queue: default
+    schedule: every day at 16:15
+
+production:
+  <<: *default
+
+development:
+  <<: *default


### PR DESCRIPTION
フリースクールの稼働日には「その日のボランティアの参加状況」「直近30日間のボランティアの参加状況」をDiscordに通知することにしてみます。

- たくさん参加してくれている人にたくさん感謝したり
- 「最近、ボランティアの参加は増えている？減っている？」を確認しやすくしたり

といった狙いがあります :dart:
